### PR TITLE
Fixed PR-AWS-TRF-S3-007: AWS S3 Object Versioning is disabled

### DIFF
--- a/aws/static_website_ssl_cloudfront_private_s3/main.tf
+++ b/aws/static_website_ssl_cloudfront_private_s3/main.tf
@@ -19,6 +19,10 @@ module "acm" {
 resource "aws_s3_bucket" "this" {
   bucket = var.bucket_name
   tags   = var.tags
+
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "website_bucket" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-007 

 **Violation Description:** 

 This policy identifies the S3 buckets which have Object Versioning disabled. S3 Object Versioning is an important capability in protecting your data within a bucket. Once you enable Object Versioning, you cannot remove it; you can suspend Object Versioning at any time on a bucket if you do not wish for it to persist. It is recommended to enable Object Versioning on S3. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>