### PR TITLE
Fixed PR-AWS-TRF-S3-007: AWS S3 Object Versioning is disabled

### DIFF
--- a/aws/aws_static_site/s3.tf
+++ b/aws/aws_static_site/s3.tf
@@ -22,13 +22,17 @@ resource "aws_s3_bucket" "this" {
     index_document = "index.html"
     error_document = "error.html"
   }
+
+  versioning {
+    enabled = true
+  }
 }
 
 # Use a bucket policy (instead of the simpler acl = "public-read") so we don't need to always remember to upload objects with:
 # $ aws s3 cp --acl public-read ...
 # https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
 resource "aws_s3_bucket_policy" "this" {
-  depends_on = ["aws_s3_bucket.this"]                      # because we refer to the bucket indirectly, we need to explicitly define the dependency
+  depends_on = ["aws_s3_bucket.this"] # because we refer to the bucket indirectly, we need to explicitly define the dependency
   count      = "${var.bucket_override_name == "" ? 1 : 0}"
   bucket     = "${local.bucket_name}"
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-007 

 **Violation Description:** 

 This policy identifies the S3 buckets which have Object Versioning disabled. S3 Object Versioning is an important capability in protecting your data within a bucket. Once you enable Object Versioning, you cannot remove it; you can suspend Object Versioning at any time on a bucket if you do not wish for it to persist. It is recommended to enable Object Versioning on S3. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>